### PR TITLE
Improve markdown format for Window's README

### DIFF
--- a/doc/README_windows.md
+++ b/doc/README_windows.md
@@ -1,19 +1,17 @@
-#XtraBYtes  1.1.0.4
+# XtraBYtes v1.1.0.4
 
-##Intro
-
+## Intro
 XtraBYtes is a free open source peer-to-peer electronic cash system that is
 completely decentralized, without the need for a central server or trusted
-parties.  Users hold the crypto keys to their own money and transact directly
+parties. Users hold the crypto keys to their own money and transact directly
 with each other, with the help of a P2P network to check for double-spending.
+
 XtraBYtes has created something called Proof of Signature which ensure that 
 100% of all blocks will be signed by the system when they occur. The blocks 
 are signed by the network of Master Nodes after verifying the transactions in 
 the block. There are a total of 650 million XBY and there will never be more.
 
-
-##Setup
-
+## Setup
 Unpack the files into a directory and run xtrabytes-qt.exe.
 
 XtraBYtes Core downloads and stores the entire history of XtraBYtes transactions;


### PR DESCRIPTION
The markdown format required titles to have at least a space between heading marks (#) and text.